### PR TITLE
Add id and status for each connector

### DIFF
--- a/custom_components/chargecloud/sensor.py
+++ b/custom_components/chargecloud/sensor.py
@@ -104,6 +104,8 @@ class ChargeCloudRealtimeSensor(
             else None,
             "connectors": [
                 {
+                    "id": connector.id,
+                    "status": connector.status,
                     "power_type": connector.power_type,
                     "ampere": connector.ampere,
                     "voltage": connector.voltage,


### PR DESCRIPTION
Add id and status for each connector.
Useful for when some connectors are reserved for specific uses (company vehicles only, etc.).